### PR TITLE
First version of calibration wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ output/
 depthai-core/
 depthai-python/
 depthai*-install/
+tmp/

--- a/CALIBRATION.md
+++ b/CALIBRATION.md
@@ -1,0 +1,26 @@
+# OAK-D device calibration
+
+To calibrate your OAK-D device you need 1) Docker installed, 2) a screen to display the calibration target on, and 3) a ruler.
+
+1. Allow all users to read and write to Myriad X devices (OAK-D device)
+```
+echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666"' | sudo tee /etc/udev/rules.d/80-movidius.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+ ```
+
+2. Download calibration target from [Kalibr](https://github.com/ethz-asl/kalibr/wiki/downloads), direct G-Drive link: https://drive.google.com/file/d/0B0T1sizOvRsUdjFJem9mQXdiMTQ/edit?usp=sharing. Put this in full screen mode on your screen.
+
+
+3. Record a video session where you move the OAK-D device in 6 degrees of freedom at moderate speed to avoid motion blur while having the target in full sight of the cameras. To start the recording, use command below to start and CTRL+C to stop recording.
+```
+./docker-record.sh
+```
+The recording session will be store in `output/<date>` folder, you can check that it looks good before moving forward.
+
+4. Next you need to have the ruler at hand an measure the full width of the apriltag grid, this means the length of 6 tags plus 7 smaller solid squares in centimeters. Use following command to start the calibration, give your recorded session as first parameter and the measurement (cm) as second. The calibration will take several minutes to complete.
+```
+# For example ./calibrate.sh output/2021-07-13T135814/ 66.5
+./docker-calibrate.sh output/<date>/ <cm>
+```
+
+5. You are done! Your calibratation results are in `./tmp/camera_calibration_raw/calibration.json` file!

--- a/docker-calibrate.sh
+++ b/docker-calibrate.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Usage:
+#
+#   ./calibrate.sh recording-folder aprilgrid-in-cm
+#
+# where the folder should contain the files data.jsonl, data.???. data2.???,
+# that represent a sequence where a calibration pattern is filmed appropriately.
+
+
+#!/bin/bash
+
+set -eu -o pipefail
+
+CAM_MODEL=pinhole-radtan
+tmp_dir=tmp
+DOCKER_KALIBR_RUN="docker run -v `pwd`/$tmp_dir:/kalibr -it stereolabs/kalibr:kinetic"
+DOCKER_DEPTHAI_RUN="docker run -v `pwd`/$tmp_dir:/kalibr -it spectacularai/depthai-library:1.0"
+APRIL_GRID=$2
+
+rm -rf tmp
+mkdir -p tmp/allan
+cp -R "$1" $tmp_dir/camera_calibration_raw
+
+aprilTag=$(LC_NUMERIC="C" awk "BEGIN {printf \"%.8f\",${APRIL_GRID}/810.0}") # cm -> m and divide by 8.1
+printf "target_type: 'aprilgrid'
+tagCols: 6
+tagRows: 6
+tagSize: ${aprilTag}
+tagSpacing: 0.3" >> $tmp_dir/april_6x6_80x80cm.yaml
+
+# TODO: These are probably not correct?
+printf "accelerometer_noise_density: 0.00074562202949377
+accelerometer_random_walk: 0.0011061605306550387
+gyroscope_noise_density: 3.115084637301622e-05
+gyroscope_random_walk: 1.5610557862757885e-05
+rostopic: /imu0
+update_rate: 600
+" >> $tmp_dir/allan/imu.yaml
+
+$DOCKER_DEPTHAI_RUN python3 /scripts/jsonl-to-kalibr.py /kalibr/camera_calibration_raw -output /kalibr/converted/
+$DOCKER_KALIBR_RUN kalibr_bagcreater --folder /kalibr/converted --output-bag /kalibr/data.bag
+set +e
+$DOCKER_KALIBR_RUN bash -c "cd /kalibr && kalibr_calibrate_cameras --bag data.bag \
+    --topics /cam0/image_raw /cam1/image_raw \
+    --models $CAM_MODEL $CAM_MODEL \
+    --target april_6x6_80x80cm.yaml \
+    --dont-show-report"
+$DOCKER_KALIBR_RUN bash -c "cd kalibr && kalibr_calibrate_imu_camera --bag data.bag \
+    --cams camchain-data.yaml \
+    --target april_6x6_80x80cm.yaml \
+    --imu allan/imu.yaml  \
+    --dont-show-report"
+set -e
+$DOCKER_DEPTHAI_RUN python3 /scripts/kalibr-to-calibration.py /kalibr/camchain-imucam-data.yaml -output /kalibr/camera_calibration_raw/

--- a/docker-calibrate.sh
+++ b/docker-calibrate.sh
@@ -14,7 +14,7 @@ set -eu -o pipefail
 CAM_MODEL=pinhole-radtan
 tmp_dir=tmp
 DOCKER_KALIBR_RUN="docker run -v `pwd`/$tmp_dir:/kalibr -it stereolabs/kalibr:kinetic"
-DOCKER_DEPTHAI_RUN="docker run -v `pwd`/$tmp_dir:/kalibr -it spectacularai/depthai-library:1.0"
+DOCKER_DEPTHAI_RUN="docker run -v `pwd`/$tmp_dir:/kalibr -it ghcr.io/spectacularai/depthai-library:1.0"
 APRIL_GRID=$2
 
 rm -rf tmp

--- a/docker-calibrate.sh
+++ b/docker-calibrate.sh
@@ -14,7 +14,7 @@ set -eu -o pipefail
 CAM_MODEL=pinhole-radtan
 tmp_dir=tmp
 DOCKER_KALIBR_RUN="docker run -v `pwd`/$tmp_dir:/kalibr -it stereolabs/kalibr:kinetic"
-DOCKER_DEPTHAI_RUN="docker run -v `pwd`/$tmp_dir:/kalibr -it ghcr.io/spectacularai/depthai-library:1.0"
+DOCKER_DEPTHAI_RUN="docker run -v `pwd`/$tmp_dir:/kalibr -it ghcr.io/spectacularai/kalibr-conversion:1.0"
 APRIL_GRID=$2
 
 rm -rf tmp

--- a/docker-record.sh
+++ b/docker-record.sh
@@ -6,5 +6,5 @@ docker run --rm --privileged \
 	-e DISPLAY=$DISPLAY \
 	-v /tmp/.X11-unix:/tmp/.X11-unix \
 	-v `pwd`:/host \
-	luxonis/depthai-library:latest \
+	luxonis/depthai-library:v2.6.0.0 \
 	python3 /host/record.py -o /host/output $@


### PR DESCRIPTION
Use dockerized kalibr/python scripts to run calibration. Use exact version of luxonis/depthai-library docker image, the latest was pretty old.